### PR TITLE
https://trello.com/c/dTEPrvKO/1036-php-warning-invalid-argument-supplied-for-foreach-in-var-www-plazarocom-private-app-models-modules-channelmanagermodulephp460

### DIFF
--- a/src/ErrorLogger.php
+++ b/src/ErrorLogger.php
@@ -57,6 +57,8 @@ class ErrorLogger extends \Tracy\Logger {
 			$securityUser = $container->getByType('\Nette\Security\User');
 			$logger->injectSecurityUser($securityUser);
 		} catch (\Exception $e) {}
+
+		return $logger;
 	}
 
 	public function __construct($container, $directory, $email = NULL, \Tracy\BlueScreen $blueScreen = NULL)


### PR DESCRIPTION
Logy chceme obalit  do nasej vlastnej triedy ErrorLogger aby sme mohli modifikovat error message. Preto potrebujeme aby `ADT\ErrorLogger` vo funkcii `install()` vracal instanciu triedy `ErrorLogger`.